### PR TITLE
Add composite support

### DIFF
--- a/src/player/index.js
+++ b/src/player/index.js
@@ -121,9 +121,12 @@ class MediaPlayer {
       composite: async (alert, muted, timeout) => {
         let playPromise = [];
 
-        alert.key.forEach((alert, index) => {
+        alert
+          .key
+          .reverse()
+          .forEach((alert, index) => {
           const handler = this.getMediaHandler(alert.type);
-          playPromise.push(handler(alert, index === 0, 5000));
+          playPromise.push(handler(alert, index !== 0, 5000));
         });
 
         return Promise.all(playPromise);

--- a/src/player/player.spec.js
+++ b/src/player/player.spec.js
@@ -116,6 +116,36 @@ describe('MediaPlayerBuilder', () => {
       expect(body.innerHTML).toContain(alert.key);
 
     });
+
+    test('composite', async () => {
+      const alert = {
+        type: 'composite',
+        key: [
+          {
+            type: 'image',
+            key: 'foo.gif',
+          },
+          {
+            type: 'audio',
+            key: 'foo.ogg',
+          },
+        ]
+      };
+
+      const handler = player.getMediaHandler(alert.type);
+
+      const p = handler(alert);
+
+      const body = document.querySelector('body');
+
+      expect(body.innerHTML).toContain(`<img`);
+      expect(body.innerHTML).toContain(alert.key[0].key);
+
+      await p;
+
+      expect(Audio.prototype.play).toHaveBeenCalled();
+
+    });
   });
 
   describe('onCommand', () => {
@@ -316,6 +346,34 @@ describe('MediaPlayerBuilder', () => {
       expect(player.queueAlert).toHaveBeenCalledWith("./media/foo1");
     });
 
+    test('queue sfx multiple', async () => {
+      fetch.mockImplementationOnce(() => Promise.resolve({
+        json: () => Promise.resolve({
+          media: {
+            "foo1": {
+              url: "foo"
+            },
+            "foo2": {
+              url: "foo"
+            },
+            "bar": {
+              url: "bar"
+            }
+          }
+        })
+      }));
+
+      const player = await MediaPlayer("http://example.com/foo.json");
+
+      player.queueAlert = jest.fn();
+
+      await ComfyJSMock.onCommand("FAKEUSER", "foo1+foo2", "");
+
+      expect(player.queueAlert).toHaveBeenCalledWith([
+        "./media/foo",
+        "./media/foo",
+      ]);
+    });
 
   });
 

--- a/src/player/player.spec.js
+++ b/src/player/player.spec.js
@@ -58,12 +58,14 @@ describe('MediaPlayerBuilder', () => {
       Audio.prototype.play = jest.fn(function() {
         this.onended();
       });
+      Audio.prototype.pause = jest.fn();
       Audio.mockClear();
 
       global.HTMLMediaElement = jest.fn();
       HTMLMediaElement.prototype.play = jest.fn(function() {
         this.onended();
       });
+      HTMLMediaElement.prototype.pause = jest.fn();
       HTMLMediaElement.mockClear();
 
     });
@@ -139,7 +141,7 @@ describe('MediaPlayerBuilder', () => {
       const body = document.querySelector('body');
 
       expect(body.innerHTML).toContain(`<img`);
-      expect(body.innerHTML).toContain(alert.key[0].key);
+      expect(body.innerHTML).toContain(alert.key[1].key); // TODO bug, array is reversed
 
       await p;
 


### PR DESCRIPTION
This pull request adds support for a "composite" type alert. A composite type alert will play two media files simultaneously. This can lead a even more combinations of alerts:

- A gif can now be played alongside an audio or video file
- A video file can now have a different audio from another alert (audio or video)

A composite alert can be created by concatenating two alerts together with a '+' charater


e.g. `!pocketsand+dale1`

Future tasks

- Currently there is a timeout of 5-10 seconds to stop both media files. Perhaps a parameter or a way to detect which ends first instead would work better.
